### PR TITLE
Fix build [#22]

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -224,7 +224,7 @@ my $orig = \&ExtUtils::MM_Unix::c_o;
 	foreach (@rv) {
 		# add c++0x flag only for cpp files
 		# otherwise XS perl handshake fails
-		s/\$\*\.c(pp|xx)(?=\n|\Z)/-xc++ -std=c++0x \$\*\.c$1/g
+		s/\$\*\.c(pp|xx)\s*(?=\n|\r|\Z)/-xc++ -std=c++0x \$\*\.c$1/g
 	}
 	return @rv;
 };


### PR DESCRIPTION
Not sure what the removed parenthetical is supposed to be doing, but based on the values I see in , it won't ever match.

This change fixes the build issues I see on both MacOS X and Linux.